### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Um servidor MCP completo para integração com Sentry no Cursor, oferecendo 27 ferramentas para monitoramento de erros, performance e saúde de aplicações.
 
+<a href="https://glama.ai/mcp/servers/@diegofornalha/sentry-mcp-cursor">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@diegofornalha/sentry-mcp-cursor/badge" alt="Sentry para Cursor MCP server" />
+</a>
+
 ## ✨ Características
 
 - **27 Ferramentas Completas**: 12 SDK + 15 API


### PR DESCRIPTION
This PR adds a badge for the [MCP Sentry para Cursor](https://glama.ai/mcp/servers/@diegofornalha/sentry-mcp-cursor) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@diegofornalha/sentry-mcp-cursor">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@diegofornalha/sentry-mcp-cursor/badge" alt="Sentry para Cursor MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.